### PR TITLE
Fixed crash on startup with Common Dialog

### DIFF
--- a/ARRBetterMap/MainWindow.xaml.cs
+++ b/ARRBetterMap/MainWindow.xaml.cs
@@ -72,7 +72,7 @@ namespace ARRBetterMap
             OpenFileDialog dlg = new OpenFileDialog();
             dlg.DefaultExt = ".sav";
             dlg.Filter = "RailroadsOnline save file (*.sav)|*.sav";
-            string arrDir = System.IO.Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "arr/saved/savegames/");
+            string arrDir = System.IO.Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), @"arr\saved\savegames\");
             if (Directory.Exists(arrDir))
                 dlg.InitialDirectory = arrDir;
 


### PR DESCRIPTION
Looks like Common Dialog does not like unix path, atleast for me with Win11